### PR TITLE
Use default command name in help output

### DIFF
--- a/click_default_group.py
+++ b/click_default_group.py
@@ -94,6 +94,7 @@ class DefaultGroup(click.Group):
         cmd_name, cmd, args = base.resolve_command(ctx, args)
         if hasattr(ctx, 'arg0'):
             args.insert(0, ctx.arg0)
+            cmd_name = cmd.name
         return cmd_name, cmd, args
 
     def format_commands(self, ctx, formatter):


### PR DESCRIPTION
Set command name when the default command is implicitly invoked.

Fixes #11 