### PR TITLE
Stop use default command on complition

### DIFF
--- a/click_default_group.py
+++ b/click_default_group.py
@@ -47,6 +47,7 @@
 import warnings
 
 import click
+import os
 
 
 __all__ = ['DefaultGroup']
@@ -78,7 +79,9 @@ class DefaultGroup(click.Group):
         self.default_cmd_name = cmd_name
 
     def parse_args(self, ctx, args):
-        if not args and self.default_if_no_args:
+        complete_var = f"_{ctx.info_name}_COMPLETE".replace("-", "_").upper()
+        instruction = os.environ.get(complete_var)
+        if not (args or instruction) and self.default_if_no_args:
             args.insert(0, self.default_cmd_name)
         return super(DefaultGroup, self).parse_args(ctx, args)
 


### PR DESCRIPTION
If `_{prog_name}_COMPLETE` is set, the click will execute completion instead of normal flow.
On completion, adding the default command name to arg cause trouble.